### PR TITLE
Add dummy user registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.26.0",
+    "bcrypt": "^3.0.2",
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "dotenv": "^6.1.0",
     "express": "^4.16.4",
+    "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",
     "validator": "^10.9.0"

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ import logger from 'morgan';
 import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import cookiePasrer from 'cookie-parser';
+import routes from './routes';
 
 dotenv.config();
 const app = express();
@@ -13,6 +14,7 @@ app.use(logger('dev'));
 app.use(bodyParser.json({ limit: '10mb' }));
 app.use(bodyParser.urlencoded({ limit: '10mb', extended: false }));
 app.use(cookiePasrer());
+app.use(routes.authRoutes);
 
 app.all('/api', (req, res) => {
   res.status('200').send({

--- a/server/collections/index.js
+++ b/server/collections/index.js
@@ -1,0 +1,45 @@
+/**
+ * 
+ * @export
+ * @class Collections
+ */
+class Collections {
+	/**
+	 * Creates an instance of Collection.
+	 * @memberof Collection
+	 */
+	constructor() {
+		this.users = [];
+	}
+
+	/**
+	 * Add new user to user collection
+	 * 
+	 * @param {any} user
+	 * @memberof Collections
+	 */
+	addUsers(user) {
+		this.users.push(user);
+	}
+
+	/**
+	 * Get the number of users 
+	 * 
+	 * @returns {number} Returns the number of users
+	 * @memberof Collections
+	 */
+	getUsersCount() {
+		return this.users.length;
+	}
+
+	/**
+	 * Get users collection
+	 * 
+	 * @returns {Array} Returns an array of users
+	 * @memberof Collection
+	 */
+	getUsers() {
+		return this.users;
+	}
+}
+export default new Collections();

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,0 +1,6 @@
+import UserController from './userController';
+
+const controllers = {
+  UserController,
+};
+export default controllers;

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+import dotenv from 'dotenv';
+import bcrypt from 'bcrypt';
+import collections from '../collections';
+import UtilityService from '../services/utilityService';
+
+dotenv.load();
+
+/**
+ * @export
+ * @class UserController
+ * @extends { UtilityService }
+ */
+export default class UserController extends UtilityService {
+	/**
+	 * 
+	 * @static
+	 * @returns {function} aA middleware function that handles the POST request
+	 * @memberof UserController
+	 */
+	static register() {
+		return (req, res) => {
+			const hashSalt = bcrypt.genSaltSync(10);
+			req.body.password = bcrypt.hashSync(req.body.password, hashSalt);
+			req.body.userId = collections.getUsersCount() + 1;
+			req.body.isAdmin = _.isUndefined(req.body.isAdmin) ? false : req.body.isAdmin;
+
+			collections.addUsers(req.body);
+
+			const { password, ...data } = req.body;
+			data.createdAt = new Date();
+			return this.successResponse(res, 201, 'Registration was successful', data );
+			// res.status(201).json({
+			// 	status: 'Success',
+			// 	message: 'Registration was successful',
+			// 	data: {
+			// 		...data
+			// 	}
+			// });
+		};
+	}
+}

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import controllers from '../controllers';
+import validations from '../validations';
+
+const { UserController } = controllers;
+const { UserValidations } = validations;
+const authRouter = express.Router();
+
+authRouter.post('/api/v1/auth/signup',
+  UserValidations.isRequired(),
+  UserValidations.validateRegistration(),  
+  UserValidations.isUnique('Email', 'E-mail address has been used!'),
+  UserValidations.isUnique('Phone', 'Phone number has been used!'),
+  UserController.register());
+
+export default authRouter;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,7 @@
+import authRoutes from './authRoutes';
+
+const routes = {
+  authRoutes,
+};
+
+export default routes;

--- a/server/services/utilityService.js
+++ b/server/services/utilityService.js
@@ -1,0 +1,142 @@
+import _ from 'lodash';
+
+/**
+ * @description
+ * @class UtilityService
+ */
+export default class UtilityService {
+	/**
+	 * Converts the first character of a string to upper case
+	 * If an object is passed, the method only convert its string 
+	 * propeties
+     * 
+	 * @static
+	 * @method upperCaseFirst
+	 * @memberof UtilityService
+	 * @param {(Object|String)} attributes The object whose string properties
+	 * is or the string to be converted
+	 * @param {Boolean} options
+	 * Note: options.bool: if true, first character of every word will be
+	 * 		 	 capitalize; if false (default), only the first character of the sentence 
+	 * 		   will be capitalize
+	 *       options.skip: array of words to skip
+	 * @returns {(Object|String)} An object with converted string attributes or a 
+	 * converted string
+	 */
+  static upperCaseFirst(attributes, options) {
+    let attr = null;
+    const bool = (options && !_.isUndefined(options.bool)) ? options.bool : false;
+    const skip = (options && !_.isUndefined(options.skip)) ? options.skip : [];
+    if (_.isObject(attributes)) {
+      attr = {};
+      for (let key in attributes) {
+        if (!_.isUndefined(key)) {
+          if (_.isString(attributes[key])) {
+            if (bool) {
+              const array = attributes[key].split(' ');
+              attr[key] = array.map((str) => {
+                str = str.toString().trim();
+                return (skip.includes(str))
+                  ? str
+                  : str.charAt(0).toUpperCase() + str.substr(1);
+              }).join(' ');
+            } else {
+              const str = attributes[key].toString().trim();
+              attr[key] = (skip.includes(str))
+                ? str
+                : str.charAt(0).toUpperCase() + str.substr(1);
+            }
+          } else attr[key] = attributes[key];
+        }
+      }
+    } else if (_.isString(attributes)) {
+      if (bool) {
+        const array = attributes.split(' ');
+        attr = array.map((str) => {
+          str = str.toString().trim();
+          return (skip.includes(str))
+            ? str
+            : this.cleanString(str.charAt(0).toUpperCase() + str.substr(1));
+        }).join(' ');
+      } else {
+        const str = attributes.toString().trim();
+        attr = (skip.includes(str))
+          ? str
+          : str.charAt(0).toUpperCase() + str.substr(1);
+      }
+    } else attr = attributes;
+    return attr;
+  }
+
+
+	/**
+	 * Removes any leading/trialing white space character from object's attributes
+	 * @static
+	 * @method trimAttr
+	 * @memberof UtilityService
+	 * @param {Object} attributes The object with the attributes to trim
+	 * @returns {Object} An object with trimed attributes
+	 */
+  static trimAttr(attributes) {
+    const trimed = {};
+    for (let key in attributes) {
+      if (attributes[key]) { 
+        trimed[key] = attributes[key].toString().trim(); 
+      }
+    }
+    return trimed;
+  }
+
+	/**
+	 * Removes all white space character, if any
+	 * @static
+	 * @method cleanString
+	 * @memberof UtilityService
+	 * @param {Strng} string The string to remove white space(s)
+	 * @param {Boolean} removeAll:  if false, multiple white space will reduced to single;
+	 * otherwise all white space(s) will be removed
+	 * @returns {Object} An object with trimed attributes
+	 */
+  static cleanString(string, removeAll) {
+    let all = (!_.isUndefined(removeAll)) ? removeAll : true;
+    return (all) ? string.trim().replace(/[ ]+/g, '') : string.trim().replace(/[ ]+/g, ' ');
+  }
+
+  /**
+   * Return an error message from the server
+   * @static
+   * @param {any} response - the reponse object
+   * @param {any} code - the error code
+   * @param {any} message - the error message
+   * @return {object} Returns the error response
+   * @memberof UtilityService
+   */
+  static errorResponse(response, code, message) {
+    return response.status(code).json({
+      status: 'Fail',
+      message
+    });
+  }
+
+  /**
+   * 
+   * 
+   * Return an error message from the server
+   * @static
+   * @param {object} response - the reponse object
+   * @param {number} code - the error code
+   * @param {string} message - the error message
+   * @param {object} data - the json object to return
+   * @return {object} Returns the error response
+   * @memberof UtilityService
+   */
+  static successResponse(response, code, message, data) {
+    return response.status(code).json({
+      status: 'Success',
+      message,
+      data: {
+        ...data
+      }
+    });
+  }
+}

--- a/server/validations/index.js
+++ b/server/validations/index.js
@@ -1,0 +1,6 @@
+import UserValidations from './userValidations';
+
+const validations = {
+	UserValidations,
+};
+export default validations;

--- a/server/validations/userValidations.js
+++ b/server/validations/userValidations.js
@@ -1,0 +1,143 @@
+import _ from 'lodash';
+import Validator from 'validator';
+import collections from '../collections';
+import UtilityService from '../services/utilityService';
+
+/**
+ * @export
+ * @class UserValidations
+ * @extends {UtilityService}
+ */
+export default class UserValidations extends UtilityService {
+  /**
+   * Validates user's sign up details
+   * @static
+   * @returns {function} Returns an express middleware function that handles the validation
+   * @memberof UserValidations
+   */
+  static validateRegistration() {
+    return (req, res, next) => {
+      let message;
+      const { 
+        email, password, firstname, lastname, gender, address, city, state, phone
+      } = this.trimAttr(req.body);
+
+      if (Validator.isEmpty(email)) {
+        message = 'Email address cannot be empty!';
+      } else if (!Validator.isEmail(email)) {
+        message = 'Please, enter a valid email address!';
+      } else if (Validator.isEmpty(password)) {
+        message = 'Password cannot be empty!';
+      } else if (password.length < 8) {
+        message = 'Password must be at least 8 characters long!';
+      } else if (Validator.isEmpty(firstname)) {
+        message = 'Firstname cannot be empty!';
+      } else if (Validator.isEmpty(lastname)) {
+        message = 'lastname cannot be empty!';
+      } else if (Validator.isEmpty(gender)) {
+        message = 'Gender cannot be empty!';
+      } else if (Validator.isEmpty(address)) {
+        message = 'Address cannot be empty!';
+      } else if (Validator.isEmpty(city)) {
+        message = 'City cannot be empty!';
+      } else if (Validator.isEmpty(state)) {
+        message = 'State cannot be empty!';
+      } else if (Validator.isEmpty(phone)) {
+        message = 'Phone number cannot be empty!';
+      }
+
+      if (_.isEmpty(message)) {
+        req.body = { 
+          email, password, firstname, lastname, gender, address, city, state, phone
+        };
+        return next();
+      }
+
+      return this.errorResponse(res, 400, message);
+    };
+  }
+
+  /**
+   * Validates if a user sign up credential has been used
+   * 
+   * @param {string} string - the property name 
+   * @param {string} message - the message to retun (optional)
+   * @static
+   * @returns {function} Returns an express middleswar function that does the validation
+   * @memberof UserValidations
+   */
+  static isUnique(string, message) {
+    return (req, res, next) => {
+      let isUnique = true;
+      let length = collections.getUsersCount();
+
+      for (let i = 0; i < length; i++) {
+        if (collections.getUsers()[i][string.toLowerCase()] === req.body[string.toLowerCase()]) {
+          isUnique = false;
+          break;
+        }
+      }
+
+      if (isUnique) {
+        return next();
+      }
+      return this.errorResponse(res, 409, (message || `${string} has been used`));
+    };
+  }
+
+  /**
+   * Validates required fields
+   * 
+   * @static
+   * @returns {function} Returns an express middleware function that handles the validation for required fields
+   * @memberof UserValidations
+   */
+  static isRequired() {
+    return (req, res, next) => {
+      let attr;
+      const { 
+        email, password, firstname, lastname, gender, address, city, state, phone 
+      } = req.body;
+      if (_.isUndefined(email)) {
+        attr = 'Email address';
+      } else if ( _.isUndefined(password)) {
+        attr = 'Password';
+      } else if ( _.isUndefined(firstname)) {
+        attr = 'Firstname';
+      } else if ( _.isUndefined(lastname)) {
+        attr = 'Lastname';
+      } else if ( _.isUndefined(gender)) {
+        attr = 'Gender';
+      } else if ( _.isUndefined(address)) {
+        attr = 'Address';
+      } else if ( _.isUndefined(city)) {
+        attr = 'City or town';
+      } else if ( _.isUndefined(state)) {
+        attr = 'State';
+      } else if ( _.isUndefined(phone)) {
+        attr = 'Phone number';
+      }
+
+      if (_.isEmpty(attr)) {
+        return next();
+      }
+
+      return this.errorResponse(res, 400, `${attr} is required!`);
+    };
+  }
+
+  /**
+   * Validates email
+   * @static
+   * @return {function} Returns an express middleware function that does the validation
+   * @memberof UserValidations
+   */
+  static isValidEmail() {
+    return (req, res, next) => {
+      if (Validator.isEmail(req.body.email)) {
+        return next();
+      }
+      return this.errorResponse(res, 400, 'Please, enter a valid email address');
+    };
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Add dummy registration functionality

#### Description of Task to be completed?
Have the following end point working
 - POST /api/v1/auth/signup

#### How should this be manually tested?
Cloning the repo

finally, launch Postman and navigate to the above route
#### Required fields
- email
- password
- firstname
- lastname
- gender
- address
- city
- state
- phone

#### What are the relevant pivotal tracker stories?
- 161583243

#### Sample screenshot
![user registration](https://user-images.githubusercontent.com/29798373/48297608-03db9f00-e4ad-11e8-8a21-b742c74ff144.png)
