### PR TITLE
Add cancel dummy parcel deliver order

### DIFF
--- a/server/controllers/parcelController.js
+++ b/server/controllers/parcelController.js
@@ -93,5 +93,50 @@ export default class ParcelController extends UtilityService {
         ? this.successResponse(res, 200, undefined, { parcels: collections.getParcels() })
         : this.errorResponse(res, 404, 'No parcel found');
     };
+	}
+	
+  /**
+   * Cancel parcel deivery order
+   * @static
+   * @returns {function} Returns an express middleware function that handles the PUT request
+   * @memberof RequestController
+   */
+  static cancelParcelOrder() {
+    return (req, res) => {
+			const parcelId = req.params.parcelId;
+			const { userId } = req.body.decoded;
+			const length = collections.getParcelsCount();
+
+      let parcel;
+      for (let i = 0; i < length; i++) {
+				if (parseInt(collections.getParcels()[i].userId, 10) === parseInt(userId, 10) 
+					&& parseInt(collections.getParcels()[i].parcelId, 10) === parseInt(parcelId, 10)) {
+          parcel = collections.getParcels()[i];
+          break;
+        }
+      }
+
+			if (parcel) {
+        const status = 'Cancelled';
+				if (parcel.deliveryStatus === 'Delivered') {
+					return this.errorResponse(
+            res, 404, 'Already delivered parcel cannot be cancelled', undefined
+            );
+        }
+        
+        if (parcel.deliveryStatus === status) {
+          return this.errorResponse(
+            res, 200, 'Parcel has already been cancelled'
+            );
+        }
+
+				parcel.deliveryStatus = status;
+				return this.successResponse(
+          res, 200, 'Parcel delivery order successfully cancelled', parcel
+          );
+			}
+
+			return this.errorResponse(res, 404, 'No parcel found');
+    };
   }
 }

--- a/server/routes/parcelRoutes.js
+++ b/server/routes/parcelRoutes.js
@@ -28,4 +28,8 @@ parcelRouter.get('/api/v1/users/:userId/parcels',
 	UserController.authenticateUser(),
 	ParcelController.getUserParcels());
 
+parcelRouter.put('/api/v1/parcels/:parcelId/cancel',
+	UserController.authenticateUser(),
+	ParcelController.cancelParcelOrder());
+
 export default parcelRouter;

--- a/server/services/utilityService.js
+++ b/server/services/utilityService.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 /**
+ * @exports
  * @description
  * @class UtilityService
  */
@@ -9,7 +10,7 @@ export default class UtilityService {
 	 * Converts the first character of a string to upper case
 	 * If an object is passed, the method only convert its string 
 	 * propeties
-     * 
+   * 
 	 * @static
 	 * @method upperCaseFirst
 	 * @memberof UtilityService


### PR DESCRIPTION
#### What does this PR do?
Add dummy data cancel parcel delivery order

#### Description of Task to be completed?
Have the following end point working
 - PUT /api/v1/parcels/:parcelId/cancel

#### How should this be manually tested?
Cloning the repo,  launch Postman and navigate to the above route

#### What are the relevant pivotal tracker stories?
- 161575688

#### Sample screenshot
![cancel dummy](https://user-images.githubusercontent.com/29798373/48318376-19ada900-e600-11e8-86dc-743911973b61.png)
